### PR TITLE
Adds default values and psutil cpu count

### DIFF
--- a/python/python_openmp/python_openmp.py
+++ b/python/python_openmp/python_openmp.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
 import os
 from time import time
+import psutil
+
 import numpy as np
 
-print('Using %d processors' % int(os.getenv('SLURM_CPUS_PER_TASK',1)))
+print('Using %d processors' % int(os.getenv('SLURM_CPUS_PER_TASK') or '1'))
+print('Using %d threads' % int(os.getenv('OMP_NUM_THREADS') or psutil.cpu_count()))
+print('Using %d tasks' % int(os.getenv('SLURM_NTASKS') or '1'))
 
 nrounds = 5
 


### PR DESCRIPTION
- Sets default values to 1 in the case the variables are not set in the batch script.
- Uses `cpu_count` of `psutil` to print the number of available CPUs (since it seems that Python spawns this many threads if `OMP_NUM_THREADS` is not initialized.